### PR TITLE
Deleted the (dead code) `main` function from the `atoz.dart` file

### DIFF
--- a/lib/pages/modules/atoz.dart
+++ b/lib/pages/modules/atoz.dart
@@ -460,7 +460,3 @@ class _AtoZState extends State<AtoZ> {
     );
   }
 }
-
-void main() {
-  runApp(const AtoZ());
-}


### PR DESCRIPTION
Fixes #108
I figured out that this main function is a dead code and need not be there. The app isn't impacted in any way if this is removed or is there.